### PR TITLE
Update deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
 rm -r public/ docs/*
-hugo
-mv public/* docs/
-git status
+hugo -d="docs"
 git add .
 git commit -m "updated BY $(git config user.name) AT $(date +"%Y-%m-%d %T")"
 git push -u origin master
-


### PR DESCRIPTION
Use a command-line argument to simplify the logic.
Remove meaningless code `git status` because its output contains a lot of things in directory `docs`, and the user can not respond to this script even if he or she finds something wrong in the output of `git status`.
Remove redundant tailing line.